### PR TITLE
remove private key from terraform vars

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,6 @@ jobs:
           terraform plan -destroy \
           -var="region=us-east-1" \
           -var="public_key=$PUBLIC_SSH_KEY" \
-          -var="private_key=$PRIVATE_SSH_KEY" \
           -var="key_name=deployer-key" \
           -out=PLAN
         working-directory: ./terraform


### PR DESCRIPTION
remove private key from terraform vars because it is redandant and just used in ssh to ec2 in the end section